### PR TITLE
refactor(blog): reorganize blog preview component structure

### DIFF
--- a/src/components/LabPostPreview/LabPostPreview.tsx
+++ b/src/components/LabPostPreview/LabPostPreview.tsx
@@ -1,14 +1,15 @@
 "use client";
 import React from "react";
 import { motion } from "motion/react";
-import type BlogPreviewProps from "@/types/blogPreview";
+import type LabPostPreviewProps from "@/components/LabPostPreview/LabPostPreview.type";
 
 function LabPostPreview({
   title,
   tags,
   publishedDate,
   excerpt,
-}: BlogPreviewProps) {
+  ...delegated
+}: LabPostPreviewProps) {
   const formattedDate = new Date(publishedDate).toLocaleDateString("en-US", {
     year: "numeric",
     month: "2-digit",
@@ -20,6 +21,7 @@ function LabPostPreview({
       whileHover={{ scale: 1.03 }}
       whileTap={{ scale: 0.99 }}
       className="flex flex-col gap-2 p-4 w-full"
+      {...delegated}
     >
       <div className="flex flex-row justify-between items-start">
         <time

--- a/src/components/LabPostPreview/LabPostPreview.type.ts
+++ b/src/components/LabPostPreview/LabPostPreview.type.ts
@@ -1,0 +1,10 @@
+import { motion } from "motion/react";
+import type { ComponentProps } from "react";
+
+export default interface LabPostPreviewProps
+  extends ComponentProps<typeof motion.article> {
+  title: string;
+  tags: string[];
+  publishedDate: string;
+  excerpt: string;
+}

--- a/src/data/labPosts.ts
+++ b/src/data/labPosts.ts
@@ -1,4 +1,4 @@
-import type BlogPreviewProps from "@/types/blogPreview";
+import type BlogPreviewProps from "@/components/LabPostPreview/LabPostPreview.type";
 
 export interface LabPost extends BlogPreviewProps {
   id: string;

--- a/src/types/blogPreview.ts
+++ b/src/types/blogPreview.ts
@@ -1,6 +1,0 @@
-export default interface BlogPreviewProps {
-  title: string;
-  tags: string[];
-  publishedDate: string;
-  excerpt: string;
-}


### PR DESCRIPTION
- Move types to component directory for better organization
- Update type definitions to use proper interfaces
- Refactor component to match new type structure
- Improve component organization and maintainability

Closes #12